### PR TITLE
feat: Implement share story as image functionality

### DIFF
--- a/composeApp/src/androidMain/kotlin/dev/rivu/golpoai/platform/PlatformUtility.android.kt
+++ b/composeApp/src/androidMain/kotlin/dev/rivu/golpoai/platform/PlatformUtility.android.kt
@@ -1,18 +1,91 @@
 package dev.rivu.golpoai.platform
 
 import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.net.Uri
+import androidx.core.content.FileProvider
+import java.io.File
+import java.io.FileOutputStream
+import android.text.StaticLayout
+import android.text.Layout
+import android.text.TextPaint
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import dev.rivu.golpoai.ContextWrapper
 import java.util.UUID
+import android.util.Log // Import Log for error logging
 
-actual fun PlatformUtility.shareStory(contextWrapper: ContextWrapper, story: String) {
-    val context = contextWrapper.context
-    val intent = Intent(Intent.ACTION_SEND).apply {
-        type = "text/plain"
-        putExtra(Intent.EXTRA_SUBJECT, "Generated with GolpoAI")
-        putExtra(Intent.EXTRA_TEXT, "Here's a story generated with GolpoAI ✨\n\n$story")
+private fun generateStoryImage(context: android.content.Context, story: String): Uri? {
+    try {
+        val imageWidth = 1080
+        val padding = 60 // Increased padding
+        val textPaint = TextPaint().apply {
+            color = Color.BLACK
+            textSize = 48f // Increased text size
+            isAntiAlias = true
+            textAlign = Paint.Align.LEFT // Align text to left
+        }
+
+        // Calculate text height considering line breaks
+        val staticLayout = StaticLayout.Builder.obtain(story, 0, story.length, textPaint, imageWidth - 2 * padding)
+            .setAlignment(Layout.Alignment.ALIGN_NORMAL)
+            .setLineSpacing(0f, 1.2f) // Increased line spacing for readability
+            .setIncludePad(true)
+            .build()
+
+        val imageHeight = staticLayout.height + 2 * padding
+
+        val bitmap = Bitmap.createBitmap(imageWidth, imageHeight, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+
+        // Fill background
+        canvas.drawColor(Color.WHITE)
+
+        // Draw text
+        canvas.save()
+        canvas.translate(padding.toFloat(), padding.toFloat())
+        staticLayout.draw(canvas)
+        canvas.restore()
+
+        // Save image
+        val imagesDir = File(context.cacheDir, "images")
+        if (!imagesDir.exists()) {
+            imagesDir.mkdirs()
+        }
+        val imageFile = File(imagesDir, "story_${UUID.randomUUID()}.png")
+        FileOutputStream(imageFile).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+
+        // Get content URI
+        return FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", imageFile)
+    } catch (e: Exception) {
+        Log.e("PlatformUtility", "Error generating image: ${e.message}", e) // Log the error
+        return null
     }
+}
+
+actual fun PlatformUtility.shareStory(contextWrapper: ContextWrapper, story: String, imageUri: String?) {
+    val context = contextWrapper.context
+    val generatedImageUri = imageUri ?: generateStoryImage(context, story) // Use provided imageUri or generate one
+
+    val intent = Intent(Intent.ACTION_SEND)
+
+    if (generatedImageUri != null) {
+        intent.type = "image/png"
+        intent.putExtra(Intent.EXTRA_STREAM, generatedImageUri)
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) // Grant read permission for the URI
+        intent.putExtra(Intent.EXTRA_SUBJECT, "Generated with GolpoAI")
+        intent.putExtra(Intent.EXTRA_TEXT, "Here's a story generated with GolpoAI ✨\n\n$story")
+    } else {
+        intent.type = "text/plain"
+        intent.putExtra(Intent.EXTRA_SUBJECT, "Generated with GolpoAI")
+        intent.putExtra(Intent.EXTRA_TEXT, "Here's a story generated with GolpoAI ✨\n\n$story")
+    }
+
     val chooser = Intent.createChooser(intent, "Share via")
     context.startActivity(chooser)
 }

--- a/composeApp/src/androidMain/res/xml/filepaths.xml
+++ b/composeApp/src/androidMain/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="shared_images" path="images/"/>
+</paths>

--- a/composeApp/src/commonMain/kotlin/dev/rivu/golpoai/platform/PlatformUtility.kt
+++ b/composeApp/src/commonMain/kotlin/dev/rivu/golpoai/platform/PlatformUtility.kt
@@ -7,7 +7,7 @@ object PlatformUtility {
 
 }
 
-expect fun PlatformUtility.shareStory(contextWrapper: ContextWrapper, story: String)
+expect fun PlatformUtility.shareStory(contextWrapper: ContextWrapper, story: String, imageUri: String? = null)
 
 expect fun PlatformUtility.generateUUID(): String
 

--- a/composeApp/src/iosMain/kotlin/dev/rivu/golpoai/platform/PlatformUtility.ios.kt
+++ b/composeApp/src/iosMain/kotlin/dev/rivu/golpoai/platform/PlatformUtility.ios.kt
@@ -2,24 +2,83 @@ package dev.rivu.golpoai.platform
 
 import androidx.compose.runtime.Composable
 import dev.rivu.golpoai.ContextWrapper
-import platform.UIKit.UIActivityViewController
-import platform.UIKit.UIApplication
-import platform.Foundation.NSUUID
+import platform.UIKit.*
+import platform.Foundation.*
+import platform.CoreGraphics.*
+import kotlinx.cinterop.useContents // For CGRect.useContents
 
+private fun generateStoryImage(story: String): UIImage? {
+    try {
+        val imageWidth = 750.0 // Image width in points
+        val padding = 30.0    // Padding around the text
+        val fontSize = 48.0   // Font size in points
 
-actual fun PlatformUtility.shareStory(contextWrapper: ContextWrapper, story: String) {
-    val content = "Here's a story generated with GolpoAI ✨\n\n$story"
+        val textAttributes = mapOf(
+            NSFontAttributeName to UIFont.systemFontOfSize(fontSize),
+            NSForegroundColorAttributeName to UIColor.blackColor
+        )
+
+        val paragraphStyle = NSMutableParagraphStyle().apply {
+            setLineSpacing(10.0) // Adjust line spacing as needed
+        }
+        val fullAttributes = textAttributes + (NSParagraphStyleAttributeName to paragraphStyle)
+
+        val attributedString = NSAttributedString(story, attributes = fullAttributes)
+
+        val drawingWidth = imageWidth - 2 * padding
+        val textSize = attributedString.boundingRectWithSize(
+            size = CGSizeMake(drawingWidth, Double.MAX_VALUE),
+            options = NSStringDrawingUsesLineFragmentOrigin or NSStringDrawingUsesFontLeading,
+            context = null
+        ).useContents { size } // Use .useContents to access properties of CValue
+
+        val imageHeight = textSize.height + 2 * padding
+
+        val renderer = UIGraphicsImageRenderer(CGSizeMake(imageWidth, imageHeight))
+        val image = renderer.imageWithActions { context ->
+            // Fill background
+            UIColor.whiteColor.setFill()
+            context.fillRect(CGRectMake(0.0, 0.0, imageWidth, imageHeight))
+
+            // Draw text
+            attributedString.drawInRect(CGRectMake(padding, padding, drawingWidth, textSize.height))
+        }
+        return image
+    } catch (e: Exception) {
+        // Basic error logging (consider a more robust logging mechanism for production)
+        println("Error generating image: ${e.message}")
+        return null
+    }
+}
+
+actual fun PlatformUtility.shareStory(contextWrapper: ContextWrapper, story: String, imageUri: String?) {
+    val contentText = "Here's a story generated with GolpoAI ✨\n\n$story"
+    val activityItems = mutableListOf<Any>()
+    activityItems.add(contentText)
+
+    // Generate image (imageUri is a signal, actual image is generated)
+    val generatedImage = generateStoryImage(story)
+    if (generatedImage != null) {
+        activityItems.add(generatedImage)
+    }
+
     val activityController = UIActivityViewController(
-        activityItems = listOf(content),
+        activityItems = activityItems,
         applicationActivities = null
     )
-    val rootVC = UIApplication.sharedApplication.keyWindow?.rootViewController
-    rootVC?.presentViewController(activityController, animated = true, completion = null)
+
+    // Try to find the most appropriate view controller to present from
+    var presentingViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
+    while (presentingViewController?.presentedViewController != null) {
+        presentingViewController = presentingViewController.presentedViewController
+    }
+
+    presentingViewController?.presentViewController(activityController, animated = true, completion = null)
 }
 
 @Composable
 actual fun PlatformUtility.getContext(): ContextWrapper {
-    return ContextWrapper()
+    return ContextWrapper() // ContextWrapper is not used for specific functionalities in iOS like in Android
 }
 
 actual fun PlatformUtility.generateUUID(): String = NSUUID().UUIDString()


### PR DESCRIPTION
This commit introduces the capability to share stories as generated images alongside the original text.

Key changes:
- Modified `PlatformUtility.shareStory` in `commonMain` to accept an optional image identifier, though current implementations generate images internally.
- **Android:**
    - Implemented `generateStoryImage` in `PlatformUtility.android.kt` to create a Bitmap with the story text rendered on it.
    - The Bitmap is saved to the app's cache directory, and a content URI is obtained using `FileProvider`.
    - `filepaths.xml` was added to support `FileProvider`.
    - The Android `shareStory` intent now includes `EXTRA_STREAM` with the image URI and sets the type to `image/png`. Text is still included via `EXTRA_TEXT`.
- **iOS:**
    - Implemented `generateStoryImage` in `PlatformUtility.ios.kt` to create a `UIImage` with the story text rendered on it using Core Graphics.
    - The iOS `shareStory` method now includes the generated `UIImage` in the `activityItems` for `UIActivityViewController`, along with the story text.
- No changes were required in `StoryDetailScreen.kt` as the image generation is encapsulated within the platform-specific share implementations.

This enhancement allows you to share a visual representation of your generated stories, improving the sharing experience.